### PR TITLE
[FEAT] 블로그 섹션 추가

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { AnimatedBackground } from '@/components/background/AnimatedBackground';
 import HeroSection from '@/components/sections/HeroSection';
 import { experienceData } from '@/constants/experience';
 import { projectData } from '@/constants/projects';
+import { Button } from '@/components/ui/button';
 
 export default function Home() {
   const [isLoading, setIsLoading] = useState(true);
@@ -203,6 +204,53 @@ export default function Home() {
                         </span>
                       ))}
                     </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* blog Section */}
+              <section id='blog' className='relative min-h-screen py-20'>
+                <div className='container mx-auto px-4 max-w-full'>
+                  <h2 className='split-text mb-12 text-center text-3xl font-bold md:text-4xl'>
+                    blog
+                  </h2>
+                  <div className='grid grid-cols-1 gap-8 md:grid-cols-3'>
+                    {[
+                      {
+                        category: '제목01',
+                        content: '이것은 프론트엔드 기술 블로그입니다.',
+                        icon: '🎨',
+                      },
+                      {
+                        category: '제목02',
+                        content: '테스트입니다.',
+                        icon: '🛠️',
+                      },
+                      {
+                        category: '제목03',
+                        content: '테스트입니다.',
+                        icon: '💻',
+                      }
+                    ].map((category, i) => (
+                      <div
+                        key={category.category}
+                        className='scroll-animate rounded-lg bg-card/50 p-6 shadow-sm backdrop-blur-sm'
+                        data-direction={i % 2 === 0 ? 'left' : 'right'}
+                      >
+                        <div className='mb-4 text-4xl'>{category.icon}</div>
+                        <h3 className='mb-4 text-xl font-semibold break-words'>
+                          {category.category}
+                        </h3>
+                        <ul className='space-y-2'>
+                          {category.content}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                  <div className='mt-8 flex justify-center'>
+                    <Button>
+                      더 보러가기
+                    </Button>
                   </div>
                 </div>
               </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -212,7 +212,7 @@ export default function Home() {
               <section id='blog' className='relative min-h-screen py-20'>
                 <div className='container mx-auto px-4 max-w-full'>
                   <h2 className='split-text mb-12 text-center text-3xl font-bold md:text-4xl'>
-                    blog
+                    Blog
                   </h2>
                   <div className='grid grid-cols-1 gap-8 md:grid-cols-3'>
                     {[
@@ -235,15 +235,15 @@ export default function Home() {
                       <div
                         key={category.category}
                         className='scroll-animate rounded-lg bg-card/50 p-6 shadow-sm backdrop-blur-sm'
-                        data-direction={i % 2 === 0 ? 'left' : 'right'}
+                        data-direction={i === 0 ? 'left' : i === 1 ? 'up' : 'right'}
                       >
                         <div className='mb-4 text-4xl'>{category.icon}</div>
                         <h3 className='mb-4 text-xl font-semibold break-words'>
                           {category.category}
                         </h3>
-                        <ul className='space-y-2'>
+                        <p className='text-muted-foreground break-words'>
                           {category.content}
-                        </ul>
+                        </p>
                       </div>
                     ))}
                   </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,10 +23,11 @@ const Header = () => {
   const navItems = useMemo<NavItem[]>(
     () => [
       { href: '#home', label: '홈' },
-      { href: '#about', label: '나에 대해' },
-      { href: '#skills', label: '내 기술' },
-      { href: '#experience', label: '내 경력' },
-      { href: '#projects', label: '내 작업' },
+      { href: '#about', label: '소개' },
+      { href: '#skills', label: '기술 스택' },
+      { href: '#experience', label: '경력' },
+      { href: '#blog', label: '블로그' },
+      { href: '#projects', label: '프로젝트' },
       { href: '#contact', label: '연락하기' },
     ],
     []


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1

<br>

## 📝 작업 내용

- header text 수정 및 아이템 추가
- 블로그 섹션 영역 임의 추가

<br>

## 🖼 스크린샷

<img width="1145" alt="스크린샷 2025-05-22 오후 12 20 33" src="https://github.com/user-attachments/assets/14130bfd-71aa-4b6d-9afa-b2d83aaf602a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - "경험"과 "프로젝트" 사이에 블로그 섹션이 추가되었습니다. 세 가지 블로그 카테고리 카드와 "더 보러가기" 버튼이 포함되어 있습니다.
- **기타**
  - 헤더 내비게이션 항목에 "블로그"가 추가되고, 기존 항목들의 라벨이 한글로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->