### PR TITLE
[FEAT] 렌더링시 페이지 상단부로 이동

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,12 +72,7 @@ export default function Home() {
           <ScrollAnimations>
             <div className="w-full max-w-5xl mx-auto">
               {/* Hero Section */}
-              <section
-                id='home'
-                className='relative flex min-h-screen items-center justify-center'
-              >
-                <HeroSection contentVisible={contentVisible} />
-              </section>
+              <HeroSection contentVisible={contentVisible} />
 
               {/* About Section */}
               <section id='about' className='relative min-h-screen py-20'>

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -15,6 +15,13 @@ const HeroSection = ({ contentVisible }: HeroSectionProps) => {
   const blurFilter = useTransform(scrollY, [0, 100], ['blur(0px)', 'blur(10px)']);
   const y = useTransform(scrollY, [0, 100], [0, 50]);
 
+  // 페이지 로드 시 맨 상단으로 스크롤
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.scrollTo(0, 0);
+    }
+  }, []);
+
   useEffect(() => {
     if (contentVisible) {
       const timer = setTimeout(() => {

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -59,7 +59,7 @@ const HeroSection = ({ contentVisible }: HeroSectionProps) => {
   const lines = text.split("\n");
 
   return (
-    <section className="min-h-screen flex items-center justify-center relative">
+    <section id='home' className="min-h-screen flex items-center justify-center relative">
       <div className="container mx-auto px-4 relative z-20 max-w-full">
         <motion.div
           className="max-w-4xl mx-auto text-left"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1

<br>

## 📝 작업 내용

- HeroSection을 페이지 구조에서 분리
- 페이지 로드 시 맨 상단으로 스크롤 기능 추가

<br>

## 🖼 스크린샷

Uploading 화면 기록 2025-05-22 오후 5.57.19.mov…


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - HeroSection 컴포넌트의 레이아웃 및 스타일이 변경되어, 더 이상 별도의 섹션이나 중앙 정렬 스타일 없이 직접 렌더링됩니다.

- **기능 개선**
  - 페이지 로드 시 화면이 항상 맨 위로 스크롤되도록 개선되었습니다.
  - HeroSection에 id="home" 속성이 추가되어 앵커 링크나 내비게이션이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->