### PR TITLE
[BUGFIX] Contact Me 아이콘 추가 및 css 수정

### DIFF
--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -42,7 +42,7 @@ const ContactSection = () => {
 
             {/* 연락처 정보 */}
             <div className='mt-8 border-t border-purple-500/20 pt-6 text-center'>
-              <div className='flex flex-col items-center justify-center gap-4 text-sm text-muted-foreground sm:flex-row'>
+              <div className='flex flex-col items-center justify-center gap-4 text-sm text-muted sm:flex-row'>
                 <span className='flex items-center gap-2'>
                   <IoMailOpenOutline />
                   <span>nosumin29@gmail.com</span>

--- a/src/constants/contact.ts
+++ b/src/constants/contact.ts
@@ -1,3 +1,6 @@
+import { FaGithub, FaLinkedin } from 'react-icons/fa';
+import { MdEmail } from 'react-icons/md';
+
 export interface ContactItem {
   href: string;
   label: string;
@@ -27,7 +30,7 @@ export const contacts: ContactItem[] = [
   },
 ];
 export const iconMap = {
-  Email: 'MdEmail',
-  GitHub: 'FaGithub',
-  LinkedIn: 'FaLinkedin',
+  Email: MdEmail,
+  GitHub: FaGithub,
+  LinkedIn: FaLinkedin,
 } as const;

--- a/src/constants/contact.ts
+++ b/src/constants/contact.ts
@@ -1,3 +1,4 @@
+import { IconType } from 'react-icons';
 import { FaGithub, FaLinkedin } from 'react-icons/fa';
 import { MdEmail } from 'react-icons/md';
 
@@ -29,8 +30,8 @@ export const contacts: ContactItem[] = [
     rel: 'noopener noreferrer',
   },
 ];
-export const iconMap = {
+export const iconMap: Record<ContactItem['label'], IconType> = {
   Email: MdEmail,
   GitHub: FaGithub,
   LinkedIn: FaLinkedin,
-} as const;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #29

<br>

## 📝 작업 내용

- Contact Me 아이콘 추가
- Contact Me 서브 연락처 텍스트 색상 변경

<br>

## 🖼 스크린샷
<img width="1394" alt="스크린샷 2025-06-13 오전 1 24 33" src="https://github.com/user-attachments/assets/1e3d2ff8-1e76-41cb-a003-0624699cb3a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 연락처 정보의 텍스트 색상이 더 명확하게 보이도록 스타일이 개선되었습니다.

- **Refactor**
  - 이메일, GitHub, LinkedIn 아이콘이 실제 아이콘 컴포넌트로 교체되어 아이콘 표시가 더욱 직관적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->