### PR TITLE
[BUGFIX] project 페이지에서 Nav 클릭 시 스크롤 이동 안 되는 문제 수정

### DIFF
--- a/src/app/page.client.tsx
+++ b/src/app/page.client.tsx
@@ -20,10 +20,9 @@ export default function HomePage() {
 
   useEffect(() => {
     if (targetSection) {
-      setActiveSection(targetSection);
       scrollToSection(targetSection);
     }
-  }, []);
+  }, [targetSection, scrollToSection]);
 
   return (
     <div

--- a/src/app/page.client.tsx
+++ b/src/app/page.client.tsx
@@ -9,9 +9,21 @@ import ProjectSection from '@/components/sections/ProjectSection';
 import BlogSection from '@/components/sections/BlogSection';
 import ExperienceSection from '@/components/sections/ExperienceSection';
 import ContactSection from '@/components/sections/ContactSection';
+import { useScrollStore } from '@/store/scrollStore';
+import { useEffect } from 'react';
+import { useScrollToSection } from '@/hooks/useScrollToSection';
 
 export default function HomePage() {
   const contentVisible = useLoadingStore((state) => state.contentVisible);
+  const targetSection = useScrollStore((state) => state.targetSection);
+  const { setActiveSection, scrollToSection } = useScrollToSection();
+
+  useEffect(() => {
+    if (targetSection) {
+      setActiveSection(targetSection);
+      scrollToSection(targetSection);
+    }
+  }, []);
 
   return (
     <div

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,8 +7,10 @@ import {
   HEADER_HEIGHT,
   MOBILE_MENU_WIDTH,
   SCROLL_THRESHOLD,
+  SECTION_OFFSET,
 } from '@/constants/header';
 import { useScrollToSection } from '@/hooks/useScrollToSection';
+import { useScrollStore } from '@/store/scrollStore';
 
 // 네비게이션 아이템 타입 정의
 type NavItem = {
@@ -22,6 +24,7 @@ const Header = () => {
   const [isNotHome, setIsNotHome] = useState<boolean>(false);
   const { activeSection, setActiveSection, scrollToSection } =
     useScrollToSection();
+  const setTargetSection = useScrollStore((state) => state.setTargetSection);
 
   const params = useParams();
   const router = useRouter();
@@ -66,7 +69,7 @@ const Header = () => {
   useEffect(() => {
     const observerOptions = {
       root: null,
-      rootMargin: `-${HEADER_HEIGHT + 50}px 0px -${window.innerHeight - HEADER_HEIGHT - 50}px 0px`,
+      rootMargin: `-${HEADER_HEIGHT + SECTION_OFFSET}px 0px -${window.innerHeight - HEADER_HEIGHT - 50}px 0px`,
       threshold: SCROLL_THRESHOLD,
     };
 
@@ -175,6 +178,8 @@ const Header = () => {
       await router.push('/');
     }
     scrollToSection(sectionId);
+    setActiveSection(sectionId);
+    setTargetSection(sectionId);
     setIsMobileMenuOpen(false);
   };
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -109,7 +109,6 @@ const Header = () => {
     };
 
     let currentSection = '';
-    let scrollTimeout: NodeJS.Timeout;
     let lastScrollY = window.scrollY;
     let ticking = false;
 
@@ -200,7 +199,6 @@ const Header = () => {
     return () => {
       observer.disconnect();
       window.removeEventListener('scroll', handleScroll);
-      clearTimeout(scrollTimeout);
       sections.forEach((section) => {
         if (section) observer.unobserve(section);
       });

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -269,16 +269,6 @@ const Header = () => {
     [isScrolled]
   );
 
-  // 로고 클릭 핸들러
-  const handleNavClickWrapper = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (isNotHome) {
-      router.push('/');
-    } else {
-      scrollToSection('home');
-    }
-  };
-
   return (
     <motion.header
       className={headerClassName}
@@ -289,7 +279,7 @@ const Header = () => {
       <div className='container mx-auto flex h-16 max-w-5xl items-center justify-between px-4'>
         <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
           <button
-            onClick={(e) => handleNavClickWrapper(e)}
+            onClick={(e) => handleNavClick(e, '/')}
             className='text-xl font-bold text-primary'
             aria-label='홈으로 이동'
           >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -3,14 +3,10 @@
 import { useState, useEffect, useCallback, useMemo, MouseEvent } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useParams, useRouter, usePathname } from 'next/navigation';
-import {
-  HEADER_HEIGHT,
-  MOBILE_MENU_WIDTH,
-  SCROLL_THRESHOLD,
-  SECTION_OFFSET,
-} from '@/constants/header';
+
 import { useScrollToSection } from '@/hooks/useScrollToSection';
 import { useScrollStore } from '@/store/scrollStore';
+import { HEADER } from '@/constants/header';
 
 // 네비게이션 아이템 타입 정의
 type NavItem = {
@@ -55,7 +51,8 @@ const Header = () => {
   const handleScroll = useCallback(() => {
     setIsScrolled(window.scrollY > 0);
     // 해당 섹션안에 들어올경우 header nav의 active 상태를 업데이트
-    const currentScrollY = window.scrollY + HEADER_HEIGHT + SECTION_OFFSET;
+    const currentScrollY =
+      window.scrollY + HEADER.HEIGHT + HEADER.SECTION_OFFSET;
     const sections = navItems
       .map((item) => document.getElementById(item.href.substring(1)))
       .filter((el): el is HTMLElement => Boolean(el));
@@ -104,8 +101,8 @@ const Header = () => {
 
     const observerOptions = {
       root: null,
-      rootMargin: `-${HEADER_HEIGHT + 50}px 0px -${window.innerHeight - HEADER_HEIGHT - 50}px 0px`,
-      threshold: SCROLL_THRESHOLD,
+      rootMargin: `-${HEADER.HEIGHT + 50}px 0px -${window.innerHeight - HEADER.HEIGHT - 50}px 0px`,
+      threshold: HEADER.SCROLL_THRESHOLD,
     };
 
     let currentSection = '';
@@ -166,7 +163,7 @@ const Header = () => {
 
       if (!ticking) {
         window.requestAnimationFrame(() => {
-          const scrollPosition = window.scrollY + HEADER_HEIGHT + 50;
+          const scrollPosition = window.scrollY + HEADER.HEIGHT + 50;
           let closestSection = sections[0];
           let minDistance = Infinity;
 
@@ -378,7 +375,7 @@ const Header = () => {
             />
             <motion.div
               className={`fixed right-0 top-0 z-40 h-screen bg-background/95 backdrop-blur-md md:hidden`}
-              style={{ width: `${MOBILE_MENU_WIDTH}px` }}
+              style={{ width: `${HEADER.MOBILE_MENU_WIDTH}px` }}
               initial='closed'
               animate='open'
               exit='closed'

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -1,3 +1,4 @@
 export const HEADER_HEIGHT = 80;
 export const SCROLL_THRESHOLD = 0.3;
 export const MOBILE_MENU_WIDTH = 200;
+export const SECTION_OFFSET = 50;

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -1,0 +1,3 @@
+export const HEADER_HEIGHT = 80;
+export const SCROLL_THRESHOLD = 0.3;
+export const MOBILE_MENU_WIDTH = 200;

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -1,4 +1,6 @@
-export const HEADER_HEIGHT = 80;
-export const SCROLL_THRESHOLD = 0.3;
-export const MOBILE_MENU_WIDTH = 200;
-export const SECTION_OFFSET = 50;
+export const HEADER = Object.freeze({
+  HEIGHT: 80,
+  SCROLL_THRESHOLD: 0.3,
+  MOBILE_MENU_WIDTH: 200,
+  SECTION_OFFSET: 50,
+});

--- a/src/hooks/useScrollToSection.ts
+++ b/src/hooks/useScrollToSection.ts
@@ -1,0 +1,22 @@
+import { HEADER_HEIGHT } from '@/constants/header';
+import { useCallback, useState } from 'react';
+
+export const useScrollToSection = () => {
+  const [activeSection, setActiveSection] = useState<string>('');
+  const scrollToSection = useCallback((sectionId: string) => {
+    const section = document.getElementById(sectionId);
+    if (!section) return;
+
+    const elementPosition = section.getBoundingClientRect().top;
+    const offsetPosition =
+      elementPosition + window.pageYOffset - HEADER_HEIGHT - 50;
+
+    setActiveSection(sectionId);
+
+    window.scrollTo({
+      top: offsetPosition,
+      behavior: 'smooth',
+    });
+  }, []);
+  return { activeSection, setActiveSection, scrollToSection };
+};

--- a/src/hooks/useScrollToSection.tsx
+++ b/src/hooks/useScrollToSection.tsx
@@ -3,20 +3,32 @@ import { useCallback, useState } from 'react';
 
 export const useScrollToSection = () => {
   const [activeSection, setActiveSection] = useState<string>('');
-  const scrollToSection = useCallback((sectionId: string) => {
-    const section = document.getElementById(sectionId);
-    if (!section) return;
+  const [isProjectsPage, setIsProjectsPage] = useState<boolean>(false);
+  const scrollToSection = useCallback(
+    (sectionId: string) => {
+      if (isProjectsPage) return;
 
-    const elementPosition = section.getBoundingClientRect().top;
-    const offsetPosition =
-      elementPosition + window.pageYOffset - HEADER_HEIGHT - SECTION_OFFSET;
+      const section = document.getElementById(sectionId);
+      if (!section) return;
 
-    setActiveSection(sectionId);
+      const elementPosition = section.getBoundingClientRect().top;
+      const offsetPosition =
+        elementPosition + window.pageYOffset - HEADER_HEIGHT - SECTION_OFFSET;
 
-    window.scrollTo({
-      top: offsetPosition,
-      behavior: 'smooth',
-    });
-  }, []);
-  return { activeSection, setActiveSection, scrollToSection };
+      setActiveSection(sectionId);
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      });
+    },
+    [isProjectsPage]
+  );
+  return {
+    activeSection,
+    setActiveSection,
+    isProjectsPage,
+    setIsProjectsPage,
+    scrollToSection,
+  };
 };

--- a/src/hooks/useScrollToSection.tsx
+++ b/src/hooks/useScrollToSection.tsx
@@ -1,4 +1,4 @@
-import { HEADER_HEIGHT, SECTION_OFFSET } from '@/constants/header';
+import { HEADER } from '@/constants/header';
 import { useCallback, useState } from 'react';
 
 export const useScrollToSection = () => {
@@ -13,7 +13,10 @@ export const useScrollToSection = () => {
 
       const elementPosition = section.getBoundingClientRect().top;
       const offsetPosition =
-        elementPosition + window.pageYOffset - HEADER_HEIGHT - SECTION_OFFSET;
+        elementPosition +
+        window.pageYOffset -
+        HEADER.HEIGHT -
+        HEADER.SECTION_OFFSET;
 
       setActiveSection(sectionId);
 

--- a/src/hooks/useScrollToSection.tsx
+++ b/src/hooks/useScrollToSection.tsx
@@ -1,4 +1,4 @@
-import { HEADER_HEIGHT } from '@/constants/header';
+import { HEADER_HEIGHT, SECTION_OFFSET } from '@/constants/header';
 import { useCallback, useState } from 'react';
 
 export const useScrollToSection = () => {
@@ -9,7 +9,7 @@ export const useScrollToSection = () => {
 
     const elementPosition = section.getBoundingClientRect().top;
     const offsetPosition =
-      elementPosition + window.pageYOffset - HEADER_HEIGHT - 50;
+      elementPosition + window.pageYOffset - HEADER_HEIGHT - SECTION_OFFSET;
 
     setActiveSection(sectionId);
 

--- a/src/store/scrollStore.ts
+++ b/src/store/scrollStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ScrollStoreProps {
+  targetSection: string | null;
+  setTargetSection: (id: string | null) => void;
+}
+
+export const useScrollStore = create<ScrollStoreProps>((set) => ({
+  targetSection: null,
+  setTargetSection: (id) => set({ targetSection: id }),
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #46

<br>

## 📝 작업 내용

- 홈이 아닌 페이지에서 nav 클릭 시, 먼저 /로 라우팅 후 스크롤 이동이 되지 않던 문제 수정
- scrollToSection 함수 호출을 router.push 이후 적절히 트리거되도록 전역 상태 및 hook 구조 개선
- Zustand를 활용하여 이동할 섹션 ID를 전역 상태로 관리하고, 홈에서 해당 값이 존재하면 자동으로 스크롤하도록 처리

<br>

## 🖼 스크린샷

이미지 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 페이지 섹션으로의 부드러운 스크롤 및 활성 섹션 상태 동기화 기능이 추가되었습니다.
	- 헤더 내비게이션에서 현재 페이지가 "/projects"일 때 섹션 감지 및 활성화 표시가 비활성화됩니다.
	- 스크롤 위치와 활성 섹션 상태를 외부 상태와 연동하여 초기 렌더링 시 자동으로 복원됩니다.
	- 스크롤 관련 상태 관리를 위한 전역 상태 저장소가 도입되었습니다.
	- 헤더, 스크롤, 모바일 메뉴 등에 사용되는 상수 값이 별도의 파일로 분리되어 유지보수가 용이해졌습니다.

- **개선 사항**
	- 스크롤 및 섹션 관리 로직이 중앙 집중화되어 더 정확한 섹션 감지와 스크롤 동작을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->