### PR TITLE
[BUGFIX] 블로그 썸네일 모바일시 이미지 영역 조절

### DIFF
--- a/src/components/sections/blogs/BlogCard.tsx
+++ b/src/components/sections/blogs/BlogCard.tsx
@@ -75,7 +75,7 @@ const BlogCard = ({ blog, index }: BlogCardProps) => {
             transformOrigin: '0 0',
           }}
         />
-        <div className='relative aspect-[1/1] w-full max-w-md'>
+        <div className='relative aspect-[1/1] w-full md:max-w-md'>
           <Image
             src={blog.imageUrl}
             alt={blog.title}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #50

<br>

## 📝 작업 내용

- BlogCard 컴포넌트에서 max-w-md 클래스의 미디어 쿼리 추가

<br>

## 🖼 스크린샷

[as-is]
<img width="533" alt="스크린샷 2025-06-16 오후 3 51 38" src="https://github.com/user-attachments/assets/71b8f8de-07d7-4b32-a464-f2d8be834511" />


[to-be]

<img width="537" alt="스크린샷 2025-06-16 오후 3 51 06" src="https://github.com/user-attachments/assets/23687492-9d5e-4ddf-bf0a-5c572b4b0743" />
