### PR TITLE
[STYLE] 프로젝트 트러블 슈팅 카드 개별 태그 간격 조절

### DIFF
--- a/src/components/sections/projects/tabs/ProjectBlog.tsx
+++ b/src/components/sections/projects/tabs/ProjectBlog.tsx
@@ -42,15 +42,17 @@ const ProjectBlog = ({ blogPosts }: ProjectBlogProps) => {
                   <p className='mb-4 text-sm leading-relaxed text-white/80'>
                     {post.description}
                   </p>
-                  {post.tags.map((tag: string, idx: number) => (
-                    <Badge
-                      key={tag}
-                      variant='outline'
-                      className={`border border-white/20 px-3 py-1 text-sm text-white/70 transition-colors duration-200 hover:bg-white/10 ${idx !== 0 ? 'ml-2' : ''}`}
-                    >
-                      {tag}
-                    </Badge>
-                  ))}
+                  <div className='flex flex-wrap gap-2'>
+                    {post.tags.map((tag: string, idx: number) => (
+                      <Badge
+                        key={tag}
+                        variant='outline'
+                        className='border border-white/20 px-3 py-1 text-sm text-white/70 transition-colors duration-200 hover:bg-white/10'
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #75

<br>

## 📝 작업 내용

- 프로젝트 섹션 트러블 슈팅 탭 카드 태그 영역 flex, gap추가

<br>

## 🖼 스크린샷

[as-is]
<img width="537" alt="스크린샷 2025-06-19 오후 6 04 51" src="https://github.com/user-attachments/assets/afb84a1b-befd-4d6c-81fe-7ea7d7848449" />


[to-be]
<img width="494" alt="스크린샷 2025-06-19 오후 6 42 46" src="https://github.com/user-attachments/assets/c0feb403-efc1-4828-9e1f-b0c470e5aa69" />
