### PR TITLE
[STYLE] 프로젝트 상세 페이지 레이아웃 구조 너비 조절

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -62,7 +62,7 @@ const page = ({ params }: PageParams) => {
   }
 
   return (
-    <div className='container relative mx-auto min-h-screen max-w-full px-4 py-20 pb-[100px]'>
+    <div className='container relative mx-auto min-h-screen max-w-5xl px-4 py-20 pb-[100px]'>
       <SectionTitle
         title={projectTitle}
         subTitle={`${projectTitle} 프로젝트에 대한 상세 정보입니다.`}

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -62,7 +62,7 @@ const page = ({ params }: PageParams) => {
   }
 
   return (
-    <div className='container relative mx-auto min-h-screen max-w-5xl px-4 py-20 pb-[100px]'>
+    <div className='relative mx-auto min-h-screen max-w-5xl px-4 py-20 pb-[100px]'>
       <SectionTitle
         title={projectTitle}
         subTitle={`${projectTitle} 프로젝트에 대한 상세 정보입니다.`}

--- a/src/components/sections/projects/ProjectDetail.tsx
+++ b/src/components/sections/projects/ProjectDetail.tsx
@@ -33,7 +33,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   const { outline, skillStack, retrospection, blogPosts } = projectDetail;
 
   return (
-    <div className='min-h-screen py-12 md:px-6 lg:px-8'>
+    <div className='min-h-screen'>
       {/* 뒤로가기 버튼 */}
       <div className='mb-10'>
         <Button


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #81

<br>

## 📝 작업 내용

- 프로젝트 상세 페이지의 전체 레이아웃 최대 너비(max-width) 조정으로 디자인 일관성 유지

<br>

## 🖼 스크린샷

[as-is]
<img width="1323" alt="스크린샷 2025-06-19 오후 7 13 29" src="https://github.com/user-attachments/assets/3c82cac3-ce00-49e2-9ba0-6afdb60f24c5" />

[to-be]
<img width="1322" alt="스크린샷 2025-06-19 오후 7 12 50" src="https://github.com/user-attachments/assets/785d8424-99ed-4b58-ae9c-852f27df9e24" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 프로젝트 상세 페이지의 본문 최대 너비가 제한되어 가독성이 향상되었습니다.
  - 프로젝트 상세 내용의 여백이 축소되어 레이아웃이 더 컴팩트하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->