### PR TITLE
[STYLE] 프로젝트 성과 제목 동적 변경 및 문서 태그 수정

### DIFF
--- a/src/components/sections/projects/ProjectDetail.tsx
+++ b/src/components/sections/projects/ProjectDetail.tsx
@@ -30,7 +30,8 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
   }
   if (!projectDetail) return null;
 
-  const { outline, skillStack, retrospection, blogPosts } = projectDetail;
+  const { projectType, outline, skillStack, retrospection, blogPosts } =
+    projectDetail;
 
   return (
     <div className='min-h-screen'>
@@ -54,7 +55,7 @@ export default function ProjectDetail({ projectId }: ProjectDetailProps) {
         {/* 탭 리스트 */}
         <ProjectTabList />
         {/* 개요 탭 */}
-        <ProjectOutline outline={outline} />
+        <ProjectOutline outline={outline} projectType={projectType} />
         {/* 기술스택 탭 */}
         <ProjectSkillStack skillStack={skillStack} />
         {/* 회고 탭 */}

--- a/src/components/sections/projects/tabs/ProjectOutline.tsx
+++ b/src/components/sections/projects/tabs/ProjectOutline.tsx
@@ -69,7 +69,13 @@ const ProjectOutline = ({ outline }: ProjectOutlineProps) => {
               </ul>
             </CardBlock>
 
-            <CardBlock title='협업 성과'>
+            <CardBlock
+              title={
+                outline.intro.introText.includes('포트폴리오')
+                  ? '개인 성과'
+                  : '협업 성과'
+              }
+            >
               <ul className='space-y-3 text-sm'>
                 {outline.achievements.collaboration.map((item, index) => (
                   <li

--- a/src/components/sections/projects/tabs/ProjectOutline.tsx
+++ b/src/components/sections/projects/tabs/ProjectOutline.tsx
@@ -6,14 +6,15 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { TabsContent } from '@/components/ui/tabs';
-import { ProjectOutlineType } from '@/types/project';
+import { ProjectOutlineType, ProjectType } from '@/types/project';
 import { Award, Lightbulb, Target, Users } from 'lucide-react';
 
 interface ProjectOutlineProps {
   outline: ProjectOutlineType;
+  projectType: ProjectType;
 }
 
-const ProjectOutline = ({ outline }: ProjectOutlineProps) => {
+const ProjectOutline = ({ outline, projectType }: ProjectOutlineProps) => {
   return (
     <TabsContent value='overview' className='space-y-8'>
       <div className='grid gap-8 lg:grid-cols-2'>
@@ -70,11 +71,7 @@ const ProjectOutline = ({ outline }: ProjectOutlineProps) => {
             </CardBlock>
 
             <CardBlock
-              title={
-                outline.intro.introText.includes('포트폴리오')
-                  ? '개인 성과'
-                  : '협업 성과'
-              }
+              title={projectType === 'individual' ? '개인 성과' : '협업 성과'}
             >
               <ul className='space-y-3 text-sm'>
                 {outline.achievements.collaboration.map((item, index) => (

--- a/src/data/projects/green-deal.ts
+++ b/src/data/projects/green-deal.ts
@@ -1,6 +1,7 @@
 import { ProjectDetail } from '@/types/project';
 
 export const greenDealDetail: ProjectDetail = {
+  projectType: 'collaboration',
   overview: {
     period: '2025.02.26 - 2025.03.04',
     role: '프론트엔드 개발',

--- a/src/data/projects/lol-stats-tracker.ts
+++ b/src/data/projects/lol-stats-tracker.ts
@@ -1,6 +1,7 @@
 import { ProjectDetail } from '@/types/project';
 
 export const lolStatsTrackerDetail: ProjectDetail = {
+  projectType: 'collaboration',
   overview: {
     period: '2025.03.10 - 2025.03.18',
     role: '프론트엔드 개발',

--- a/src/data/projects/medi-click.ts
+++ b/src/data/projects/medi-click.ts
@@ -1,6 +1,7 @@
 import { ProjectDetail } from '@/types/project';
 
 export const mediClickDetail: ProjectDetail = {
+  projectType: 'collaboration',
   overview: {
     period: '2025.03.20 - 2025.03.27',
     role: '프론트엔드 개발',

--- a/src/data/projects/portfolio.ts
+++ b/src/data/projects/portfolio.ts
@@ -1,6 +1,7 @@
 import { ProjectDetail } from '@/types/project';
 
 export const portfolioDetail: ProjectDetail = {
+  projectType: 'individual',
   overview: {
     period: '2025.05.15 - 2025.06.11',
     role: '프론트엔드 개발',

--- a/src/data/projects/portfolio.ts
+++ b/src/data/projects/portfolio.ts
@@ -63,7 +63,7 @@ export const portfolioDetail: ProjectDetail = {
     },
     {
       title: 'Documentation',
-      tags: ['Velog', 'Notion', 'GitHub Wiki'],
+      tags: ['Velog'],
       description:
         '개발 과정에서의 문제 해결과 기술적 결정 사항을 블로그와 문서로 정리하여 공유했습니다.',
     },

--- a/src/data/projects/uuno.ts
+++ b/src/data/projects/uuno.ts
@@ -1,6 +1,7 @@
 import { ProjectDetail } from '@/types/project';
 
 export const uunoDetail: ProjectDetail = {
+  projectType: 'collaboration',
   overview: {
     period: '2025.04.09 - 2025.04.30',
     role: '서브리더 & 프론트엔드 개발',

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -42,7 +42,9 @@ export interface ProjectSummary {
   githubUrl: string;
   demoUrl: string;
 }
+export type ProjectType = 'individual' | 'collaboration';
 export interface ProjectDetail {
+  projectType: ProjectType;
   overview: ProjectOverview;
   outline: ProjectOutlineType;
   skillStack: ProjectTagCard[];


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- closed #88

<br>

## 📝 작업 내용

- 기존 프로젝트 상세 페이지 텍스트 수정

<br>

## 🖼 스크린샷

이미지 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - "주요 성과 & 학습" 카드 내 두 번째 항목의 제목이 상황에 따라 '개인 성과' 또는 '협업 성과'로 동적으로 표시됩니다.
  - 포트폴리오 상세 페이지의 "Documentation" 스킬 스택 태그에서 'Notion'과 'GitHub Wiki'가 제거되고 'Velog'만 남았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->